### PR TITLE
initate vars to prevent errors when visiting index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -7,6 +7,9 @@
 
 require 'markov.php';
 
+$error = null;
+$markov = null;
+
 function process_post() {
     // generate text with markov library
     $order  = $_POST['order'];


### PR DESCRIPTION
When visiting the index.php with an internal php server you'll see two erros about variables not being initiatalized 
` Warning: Undefined variable $error in C:\Users\user\docs\markov\index.php on line 76`
    `Warning: Undefined variable $markov in C:\Users\user\docs\markov\index.php on line 80`
    
  This fix should help resolve the issue.
  
tested on php version PHP 8.1.5 with the internal php server `php -S localhost:8080`